### PR TITLE
feat: move logic to group tasks to a selector

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,23 +1,22 @@
+import { STATUS_TO_TITLE_MAPPER } from "../consts/statuses";
 import type { Statuses, TaskView } from "../types/task";
 import { Task } from "./Task";
 
 type TaskListProps = {
-  title: string;
   tasks: TaskView[];
-  status?: string;
+  status?: Statuses;
   onUpdateStatus?: (id: string, status: Statuses) => void;
 };
 
 export function TaskList({
-  title,
   tasks,
-  status,
+  status = "OPEN",
   onUpdateStatus,
 }: TaskListProps) {
   return (
     <article>
       <h1 className="text-3xl font-bold tracking-tight text-center mb-4">
-        {title}
+        {STATUS_TO_TITLE_MAPPER.get(status)}
       </h1>
       <ul>
         {tasks.map(({ title, description, id, timerSpend }) => (

--- a/src/components/TasksGroups.tsx
+++ b/src/components/TasksGroups.tsx
@@ -1,0 +1,28 @@
+import { useTasks } from "../state/tasks/useTasks";
+import { Statuses } from "../types/task";
+import { isValidStatus } from "../validators/isValidStatus";
+import { TaskList } from "./TaskList";
+
+export function TasksGroups() {
+  const { tasks, editTask } = useTasks();
+
+  const handleOnUpdateStatus = (id: string, status: Statuses) => {
+    editTask(id, { status });
+  };
+
+  return (
+    <ul className="flex flex-col md:flex-row w-full">
+      {Object.entries(tasks).map(([status, tasks]) => {
+        return (
+          <li className="flex-grow md:w-1/3 py-4 md:py-0 md:px-4" key={status}>
+            <TaskList
+              tasks={tasks}
+              status={isValidStatus(status) ? status : "OPEN"}
+              onUpdateStatus={handleOnUpdateStatus}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/consts/statuses.ts
+++ b/src/consts/statuses.ts
@@ -1,7 +1,15 @@
-export const STATUS_MAPPER = new Map([
+import { Statuses } from "../types/task";
+
+export const STATUS_MAPPER = new Map<string, Statuses>([
   ["Unstarted", "OPEN"],
   ["In Progress", "IN_PROGRESS"],
   ["Completed", "DONE"],
+]);
+
+export const STATUS_TO_TITLE_MAPPER = new Map<Statuses, string>([
+  ["OPEN", "Unstarted"],
+  ["IN_PROGRESS", "In Progress"],
+  ["DONE", "Completed"],
 ]);
 
 export const TASK_STATUSES = Array.from(STATUS_MAPPER.keys());

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,44 +1,20 @@
 import { useEffect } from "react";
-import { TaskList } from "../components/TaskList";
-import { STATUS_MAPPER, TASK_STATUSES } from "../consts/statuses";
-import type { Statuses } from "../types/task";
 import { useTasks } from "../state/tasks/useTasks";
 import { Loader } from "../components/Loader";
 import { ErrorDisplay } from "../components/ErrorDisplay";
 import { CreateTask } from "../components/CreateTask";
 import { Search } from "../components/Search";
+import { TasksGroups } from "../components/TasksGroups";
 
 export function Tasks() {
-  const { isLoaded, isLoading, tasks, error, editTask, getTasks } = useTasks();
+  const { isLoaded, isLoading, error, getTasks } = useTasks();
 
   useEffect(() => {
     getTasks();
   }, [getTasks]);
 
-  const handleOnUpdateStatus = (id: string, status: Statuses) => {
-    editTask(id, { status });
-  };
-
   const handleOnReload = () => {
     getTasks();
-  };
-
-  const renderTaskList = (status: string) => {
-    const statusIdentifier = STATUS_MAPPER.get(status);
-    const tasksByStatus = tasks.filter(
-      (task) => task.status === statusIdentifier
-    );
-
-    return (
-      <li className="flex-grow md:w-1/3 py-4 md:py-0 md:px-4" key={status}>
-        <TaskList
-          title={status}
-          tasks={tasksByStatus}
-          status={statusIdentifier}
-          onUpdateStatus={handleOnUpdateStatus}
-        />
-      </li>
-    );
   };
 
   if (error) {
@@ -56,9 +32,7 @@ export function Tasks() {
         <CreateTask />
       </header>
       <main className="m-5 p-5 border border-slate-700">
-        <ul className="flex flex-col md:flex-row w-full">
-          {TASK_STATUSES.map(renderTaskList)}
-        </ul>
+        <TasksGroups />
       </main>
     </>
   );

--- a/src/state/tasks/selectors.ts
+++ b/src/state/tasks/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 import type { ErrorMessage } from "../../types/error";
-import type { TaskView } from "../../types/task";
+import type { Statuses, TaskView } from "../../types/task";
 import type { RootState } from "../store";
 
 function _selectTasks(state: RootState): TaskView[] {
@@ -32,3 +32,21 @@ export function selectTasksError(state: RootState): ErrorMessage | undefined {
 export function selectTaskById(state: RootState, taskId: string) {
   return selectTasks(state).find((task) => task.id === taskId);
 }
+
+export const selectGroupedByStatusAndFilteredTasks = createSelector(
+  [selectTasks],
+  (tasks) => {
+    return tasks.reduce<Record<Statuses, TaskView[]>>(
+      (groupedTasks, task) => {
+        groupedTasks[task.status].push(task);
+
+        return groupedTasks;
+      },
+      {
+        OPEN: [],
+        IN_PROGRESS: [],
+        DONE: [],
+      }
+    );
+  }
+);

--- a/src/state/tasks/useTasks.ts
+++ b/src/state/tasks/useTasks.ts
@@ -1,7 +1,7 @@
 import {
+  selectGroupedByStatusAndFilteredTasks,
   selectIsTasksLoaded,
   selectIsTasksLoading,
-  selectTasks,
   selectTasksError,
 } from "./selectors";
 import { useCallback } from "react";
@@ -10,7 +10,7 @@ import { editTask, getTasks } from "./tasksSlice";
 import { useAppDispatch, useAppSelector } from "../store";
 
 export function useTasks() {
-  const tasks = useAppSelector(selectTasks);
+  const tasks = useAppSelector(selectGroupedByStatusAndFilteredTasks);
   const isLoading = useAppSelector(selectIsTasksLoading);
   const isLoaded = useAppSelector(selectIsTasksLoaded);
   const error = useAppSelector(selectTasksError);

--- a/src/validators/isValidStatus.ts
+++ b/src/validators/isValidStatus.ts
@@ -2,5 +2,5 @@ import { TASK_STATUSES_IDENTIFIERS } from "../consts/statuses";
 import type { Statuses } from "../types/task";
 
 export function isValidStatus(status: string): status is Statuses {
-  return TASK_STATUSES_IDENTIFIERS.includes(status);
+  return TASK_STATUSES_IDENTIFIERS.includes(status as Statuses);
 }


### PR DESCRIPTION
# What

- Added type safety around the usage of `Status`
- Created `TasksGroup` component to render `render` function from `Tasks` page
- Removed `filter` logic from view and moved to a selector in combination with the new `TasksGroup`