### PR TITLE
fix: adjust api handling to be in a single facade and proper handle errors between > 299 status code

### DIFF
--- a/src/state/middlewares/api.ts
+++ b/src/state/middlewares/api.ts
@@ -1,5 +1,6 @@
 import { AnyAction, Middleware } from "redux";
 import { ErrorMessage } from "../../types/error";
+import { fetchFacade } from "../../utils/api";
 import { logger } from "../../utils/logger";
 
 export const API_CALL_ACTION_TYPE = "API_CALL";
@@ -35,8 +36,7 @@ export const apiMiddleware: Middleware =
 
     next({ type: apiActions.start });
 
-    fetch(url, options)
-      .then((response) => response.json())
+    fetchFacade(url, options)
       .then((response) => {
         next({ type: apiActions.success, payload: response });
       })

--- a/src/state/tasks/sagas.ts
+++ b/src/state/tasks/sagas.ts
@@ -2,7 +2,7 @@ import { call, delay, put, select, takeLatest } from "redux-saga/effects";
 import { toTaskModel } from "../../mappers/toTaskModel";
 import { ErrorMessage } from "../../types/error";
 import { TaskModel } from "../../types/task";
-import { ENDPOINTS } from "../../utils/api";
+import { ENDPOINTS, fetchFacade } from "../../utils/api";
 import { logger } from "../../utils/logger";
 import { takeLatestById } from "../rootSaga";
 import { selectTaskById } from "./selectors";
@@ -14,15 +14,11 @@ import {
   stopTimer,
 } from "./tasksSlice";
 
-async function _editTaskClient(body: TaskModel): Promise<TaskModel> {
-  const response = await fetch(`${ENDPOINTS.EDIT_TASK}/${body.id}`, {
+function _editTaskClient(body: TaskModel): Promise<TaskModel> {
+  return fetchFacade(`${ENDPOINTS.EDIT_TASK}/${body.id}`, {
     method: "PUT",
     body: JSON.stringify(body),
-    headers: {
-      "Content-Type": "application/json",
-    },
   });
-  return await response.json();
 }
 
 export function* editTaskSaga(action: EditTaskAction) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -9,3 +9,29 @@ export const ENDPOINTS = {
   CREATE_TASK: makeApiUrl("/tasks"),
   EDIT_TASK: makeApiUrl("/tasks"),
 };
+
+export function fetchFacade<Response>(
+  url: string,
+  requestOptions?: RequestInit
+): Promise<Response> {
+  return fetch(
+    url,
+    requestOptions
+      ? {
+          ...requestOptions,
+          headers: {
+            "Content-Type": "application/json",
+            ...requestOptions.headers,
+          },
+        }
+      : undefined
+  )
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+
+      return response;
+    })
+    .then((response) => response.json());
+}


### PR DESCRIPTION
# What

- Created `fetchFacade` to encapsulate common operations when using fetch function
- Updated usage of fetch to rely on new fetch