### PR TITLE
fix: set token expiration to 1 hour

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,7 @@
 import "dotenv/config";
 
+const ONE_HOUR_IN_SECONDS = 60 * 60;
+
 export const config = {
   clientId: process.env.OAUTH_CLIENT_ID,
   clientSecret: process.env.OAUTH_CLIENT_SECRET,
@@ -8,6 +10,7 @@ export const config = {
   redirectUrl: process.env.REDIRECT_URL,
   clientUrl: process.env.CLIENT_URL,
   tokenSecret: process.env.TOKEN_SECRET,
-  tokenExpiration: 36000,
+  tokenExpirationSeconds: ONE_HOUR_IN_SECONDS,
+  tokenExpirationMilliseconds: ONE_HOUR_IN_SECONDS * 1000,
   postUrl: "https://jsonplaceholder.typicode.com/posts",
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -91,11 +91,11 @@ server.get("/auth/token", async (request: Request, response: Response) => {
 
     const user = decodedToken;
     const token = jwt.sign({ user }, config.tokenSecret, {
-      expiresIn: config.tokenExpiration,
+      expiresIn: config.tokenExpirationSeconds,
     });
 
     response.cookie("token", token, {
-      maxAge: config.tokenExpiration,
+      maxAge: config.tokenExpirationMilliseconds,
       httpOnly: true,
     });
 


### PR DESCRIPTION
# What

- Split token expiration time into seconds and milliseconds to be able to use the correct time system for JWT and the cookie.
- Redefined expiration time to 1 hour.