### PR TITLE
fix: reset error after successful API result

### DIFF
--- a/src/state/projects/projectsSlice.ts
+++ b/src/state/projects/projectsSlice.ts
@@ -64,6 +64,9 @@ const projectsSlice = createSlice({
     builder.addCase(
       createTaskApiActions.success,
       (state, { payload }: PayloadAction<TaskModel>) => {
+        state.loading = false;
+        state.error = undefined;
+
         if (!state.data) {
           return;
         }

--- a/src/state/tasks/tasksSlice.ts
+++ b/src/state/tasks/tasksSlice.ts
@@ -60,6 +60,7 @@ const tasksSlice = createSlice({
       editTasksApiActions.success,
       (state, { payload }: PayloadAction<TaskModel>) => {
         state.loading = false;
+        state.error = undefined;
 
         if (!state.data) {
           state.data = {};
@@ -75,6 +76,7 @@ const tasksSlice = createSlice({
       getProjectsApiActions.success,
       (state, { payload }: GetProjectsSuccessAction) => {
         state.loading = false;
+        state.error = undefined;
 
         if (!payload.entities.tasks) {
           return;


### PR DESCRIPTION
# What

- Added clean-up of errors on every successful API result to ensure the recover button when an error happens works as expected.